### PR TITLE
Improve speed by adding 1.5s timeout, log to console as URLs are processed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const fileService = require('./service/fileService');
 
 try {
@@ -13,17 +12,6 @@ try {
     .then((urls) => {
       service
         .checkUrls(urls)
-        .then((res) =>
-          res.forEach((e) => {
-            if (e.color === 'red') {
-              console.log(chalk.red(`${e.url} - ${e.status}`));
-            } else if (e.color === 'green') {
-              console.log(chalk.green(`${e.url} - ${e.status}`));
-            } else {
-              console.log(chalk.gray(`${e.url} - ${e.status}`));
-            }
-          })
-        )
         .catch((err) => console.log(err));
     })
     .catch((err) => console.error(err));


### PR DESCRIPTION
This change improves the slow performance issue we discussed on Slack.  It does it in three ways:

1. the code reports on URLs as they happen vs. at the end when everything is finished.  This improves the *perceived* speed of the code, since it looks like it's doing things all the time.
2. the `request()` calls now have a timeout of 1.5 seconds, see https://github.com/request/request/#timeouts.  If you don't set a timeout, and a server doesn't respond, it can take a long time for the request to come back.  Meanwhile, your program has to sit and do nothing while it waits.
3. the `request()` now *only* downloads the headers vs the headers and body.  This means responses are a lot smaller, and come back faster.  See https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD

It takes about 5 seconds to run now on your urls.txt file.