### PR TITLE
allow multiple file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 ```
     1. default
     > http-parser urls.txt or node index.js urls.txt
+    > http-parser urls1.txt urls2.html or node index.js urls1.txt urls2.html
 
     2. With timeout [ms]
     > http-parser urls.txt 5000 or node index.js urls.txt 5000

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ try {
   }
 
   else{
-    for(var i = 2; i < argv.length; i++){
+    for(let i = 2; i < argv.length; i++){
       const timeout = +argv[i+1] || 120000;
       fileService
         .readFiles(argv[i])

--- a/index.js
+++ b/index.js
@@ -11,20 +11,26 @@ try {
     throw new Error("Please provide a filename");
   }
 
-  if (utilService.isVersion(argv.slice(1))) {
-    console.log(chalk.green(`************************`));
-    console.log(chalk.green(`*        ${version}         *`));
-    console.log(chalk.green(`************************`));
-    process.exit(0);
+  else if(argv.length == 2){
+    if (utilService.isVersion(argv.slice(1))) {
+      console.log(chalk.green(`************************`));
+      console.log(chalk.green(`*        ${version}         *`));
+      console.log(chalk.green(`************************`));
+      process.exit(0);
+    }
   }
 
-  const timeout = +argv[3] || 120000;
-  fileService
-    .readFiles(argv[2])
-    .then((urls) => {
-      fileService.checkUrls(urls, timeout).catch((err) => console.log(err));
-    })
-    .catch((err) => console.error(err));
+  else{
+    for(var i = 2; i < argv.length; i++){
+      const timeout = +argv[i+1] || 120000;
+      fileService
+        .readFiles(argv[i])
+        .then((urls) => {
+          fileService.checkUrls(urls, timeout).catch((err) => console.log(err));
+        })
+        .catch((err) => console.error(err));
+    }
+  }
 } catch (err) {
   console.error(err.message);
 }


### PR DESCRIPTION
I have added a feather that supports passing multiple paths for the tool.
```sh
http-parser urls1.txt urls2.html or node index.js urls1.txt urls2.html
```
I also have added the above example to your docs.

Thanks for considering this.